### PR TITLE
[MSHARED-863] Prevent NPEx

### DIFF
--- a/src/main/java/org/apache/maven/shared/transfer/dependencies/resolve/internal/Maven30DependencyResolver.java
+++ b/src/main/java/org/apache/maven/shared/transfer/dependencies/resolve/internal/Maven30DependencyResolver.java
@@ -154,12 +154,12 @@ class Maven30DependencyResolver
         final Class<?>[] argClasses =
             new Class<?>[] { org.apache.maven.model.Dependency.class, ArtifactTypeRegistry.class };
 
-         List<Dependency> aetherDependencies;
+         List<Dependency> aetherDependencies = mavenDependencies != null
+                                                 ? new ArrayList<Dependency>( mavenDependencies.size() )
+                                                 : Collections.<Dependency>emptyList();
 
          if ( mavenDependencies != null )
          {
-             aetherDependencies = new ArrayList<Dependency>( mavenDependencies.size() );
-
              for ( org.apache.maven.model.Dependency mavenDependency : mavenDependencies )
              {
                  Object[] args = new Object[] { mavenDependency, typeRegistry };
@@ -169,10 +169,6 @@ class Maven30DependencyResolver
 
                  aetherDependencies.add( aetherDependency );
              }
-         }
-         else
-         {
-             aetherDependencies = Collections.emptyList();
          }
 
         List<Dependency> aetherManagedDependencies = null;

--- a/src/main/java/org/apache/maven/shared/transfer/dependencies/resolve/internal/Maven30DependencyResolver.java
+++ b/src/main/java/org/apache/maven/shared/transfer/dependencies/resolve/internal/Maven30DependencyResolver.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.transfer.dependencies.resolve.internal;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -153,7 +154,7 @@ class Maven30DependencyResolver
         final Class<?>[] argClasses =
             new Class<?>[] { org.apache.maven.model.Dependency.class, ArtifactTypeRegistry.class };
 
-         List<Dependency> aetherDependencies = new ArrayList<Dependency>( mavenDependencies.size() );
+         List<Dependency> aetherDependencies;
 
          if ( mavenDependencies != null )
          {
@@ -168,6 +169,10 @@ class Maven30DependencyResolver
 
                  aetherDependencies.add( aetherDependency );
              }
+         }
+         else
+         {
+             aetherDependencies = Collections.emptyList();
          }
 
         List<Dependency> aetherManagedDependencies = null;

--- a/src/test/java/org/apache/maven/shared/transfer/dependencies/resolve/internal/Maven30DependencyResolverTest.java
+++ b/src/test/java/org/apache/maven/shared/transfer/dependencies/resolve/internal/Maven30DependencyResolverTest.java
@@ -37,9 +37,13 @@ public class Maven30DependencyResolverTest
 {
     private Maven30DependencyResolver dr;
 
+    private TransformableFilter filter;
+
     @Before
     public void setUp()
     {
+      filter = mock( TransformableFilter.class );
+
       RepositorySystem system = mock( RepositorySystem.class );
       ArtifactHandlerManager manager = mock( ArtifactHandlerManager.class );
       RepositorySystemSession session = mock( RepositorySystemSession.class );
@@ -51,8 +55,6 @@ public class Maven30DependencyResolverTest
     public void resolveDependenciesWithEmptyDependenciesShouldNotThrow()
         throws DependencyResolverException
     {
-        TransformableFilter filter = mock( TransformableFilter.class );
-
         dr.resolveDependencies( new ArrayList<Dependency>(), new ArrayList<Dependency>(), filter );
     }
 
@@ -60,8 +62,6 @@ public class Maven30DependencyResolverTest
     public void resolveDependenciesWithNullMavenDependenciesShouldNotThrow()
         throws DependencyResolverException
     {
-        TransformableFilter filter = mock( TransformableFilter.class );
-
         dr.resolveDependencies( null, new ArrayList<Dependency>(), filter );
     }
 

--- a/src/test/java/org/apache/maven/shared/transfer/dependencies/resolve/internal/Maven30DependencyResolverTest.java
+++ b/src/test/java/org/apache/maven/shared/transfer/dependencies/resolve/internal/Maven30DependencyResolverTest.java
@@ -55,6 +55,16 @@ public class Maven30DependencyResolverTest
 
         dr.resolveDependencies( new ArrayList<Dependency>(), new ArrayList<Dependency>(), filter );
     }
+
+    @Test
+    public void resolveDependenciesWithNullMavenDependenciesShouldNotThrow()
+        throws DependencyResolverException
+    {
+        TransformableFilter filter = mock( TransformableFilter.class );
+
+        dr.resolveDependencies( null, new ArrayList<Dependency>(), filter );
+    }
+
 }
 
 

--- a/src/test/java/org/apache/maven/shared/transfer/dependencies/resolve/internal/Maven30DependencyResolverTest.java
+++ b/src/test/java/org/apache/maven/shared/transfer/dependencies/resolve/internal/Maven30DependencyResolverTest.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.shared.transfer.dependencies.resolve.internal;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+
+import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.shared.transfer.dependencies.resolve.DependencyResolverException;
+import org.apache.maven.shared.artifact.filter.resolve.TransformableFilter;
+import org.sonatype.aether.RepositorySystem;
+import org.sonatype.aether.RepositorySystemSession;
+import org.sonatype.aether.repository.RemoteRepository;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class Maven30DependencyResolverTest
+{
+    private Maven30DependencyResolver dr;
+
+    @Before
+    public void setUp()
+    {
+      RepositorySystem system = mock( RepositorySystem.class );
+      ArtifactHandlerManager manager = mock( ArtifactHandlerManager.class );
+      RepositorySystemSession session = mock( RepositorySystemSession.class );
+      ArrayList<RemoteRepository> repositories = new ArrayList<>();
+      dr = new Maven30DependencyResolver( system, manager, session, repositories );
+    }
+
+    @Test
+    public void resolveDependenciesWithEmptyDependenciesShouldNotThrow()
+        throws DependencyResolverException
+    {
+        TransformableFilter filter = mock( TransformableFilter.class );
+
+        dr.resolveDependencies( new ArrayList<Dependency>(), new ArrayList<Dependency>(), filter );
+    }
+}
+
+


### PR DESCRIPTION
Per change b5cc4be, dependencies can be null.
So calling `dependencies.size` in such case would throw NPEx,
or nullcheck below is unnecessary.